### PR TITLE
reduce runtime by two orders of magnitude for large inputs

### DIFF
--- a/replace_allele_counts.py
+++ b/replace_allele_counts.py
@@ -14,6 +14,17 @@ import time
 import logging
 import multiprocessing
 
+
+logger = logging.getLogger('replace_allele_counts')
+logger.propagate=False
+logger.setLevel(logging.DEBUG)
+formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
+ch=logging.StreamHandler()
+ch.setLevel(logging.DEBUG)
+ch.setFormatter(formatter)
+logger.addHandler(ch)
+
+
 try:
     import coloredlogs
     coloredlogs.install(level='DEBUG')
@@ -34,6 +45,7 @@ def main():
    parser.add_argument("-ifill","--fillout", action="store", dest="fillout", required=True, type=str, metavar='SomeID.fillout.maf', help="Input fillout file created by GetBaseCountMultiSample using the input maf")
    parser.add_argument("-omaf","--output-maf", action="store", dest="outputMaf", required=True, type=str, metavar='SomeID.maf', help="Output maf file name")
    parser.add_argument("-o", "--outDir", action="store", dest="outdir", required=False, type=str, metavar='/somepath/output', help="Full Path to the output dir.")
+   parser.add_argument("-n", "--num-threads", action="store", required=False, type=int, metavar='/somepath/output', help="number of threads to use to do merge (default 5)", default=5)
    
    args = parser.parse_args()
    logger.info("Reading Maf...")
@@ -44,7 +56,7 @@ def main():
    logger.info("Rewriting fillout lines into maf...")
    group_size = len(mafDF.index) / 10 
    dataframes = []
-   pool = multiprocessing.Pool(processes=5)
+   pool = multiprocessing.Pool(processes=args.num_threads)
    m = multiprocessing.Manager()
    q = m.Queue()
    for g, df in mafDF.groupby(np.arange(len(mafDF)) // group_size):
@@ -147,15 +159,6 @@ def write_output(args,frames, orig_chrom_order):
         bigDF[bigDF['Chromosome']==chrom].sort_values(["Start_Position", "End_Position"], ascending=True).to_csv(fh, sep='\t', index=False, header=False)
     
 if __name__ == "__main__":
-    logger = logging.getLogger('replace_allele_counts')
-    logger.propagate=False
-    logger.setLevel(logging.DEBUG)
-    formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
-    ch=logging.StreamHandler()
-    ch.setLevel(logging.DEBUG)
-    ch.setFormatter(formatter)
-    logger.addHandler(ch)
-
     start_time = time.time()  
     main()
     end_time = time.time()

--- a/replace_allele_counts.py
+++ b/replace_allele_counts.py
@@ -12,19 +12,16 @@ import sys
 import os
 import time
 import logging
+import multiprocessing
 
-logging.basicConfig(
-        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-        datefmt='%m/%d/%Y %I:%M:%S %p',
-        level=logging.DEBUG)
-logger = logging.getLogger('replace_allele_counts')
+#try:
+#    import coloredlogs
+#    coloredlogs.install(level='DEBUG')
+#except ImportError:
+#    logger.warning("replace_allele_counts: coloredlogs is not installed, please install it if you wish to see color in logs on standard out.")
+#    pass
 try:
-    import coloredlogs
-    coloredlogs.install(level='DEBUG')
-except ImportError:
-    logger.warning("replace_allele_counts: coloredlogs is not installed, please install it if you wish to see color in logs on standard out.")
-    pass
-try:
+    import numpy as np
     import pandas as pd
 except ImportError:
     logger.fatal("replace_allele_counts: pandas is not installed, please install pandas as it is required to run the removing process.")
@@ -39,12 +36,25 @@ def main():
    parser.add_argument("-o", "--outDir", action="store", dest="outdir", required=False, type=str, metavar='/somepath/output', help="Full Path to the output dir.")
    
    args = parser.parse_args()
-   if(args.verbose):
-       logger.info("replace_allele_counts: Started the run for replacing allele counts.")
+   logger.info("Reading Maf...")
    (cvDF,mafDF) =read_maf(args)
-   (filloutDF) =read_fillout(args)
-   (cleanDF) = replace_allele_count(args, mafDF, filloutDF)
-   write_output(args,cleanDF)
+   logger.info("Reading Fillout...")
+   maf_samples = np.concatenate((mafDF['Tumor_Sample_Barcode'].unique(), mafDF['Matched_Norm_Sample_Barcode'].unique()))
+   (filloutDF) =read_fillout(args, maf_samples)
+   logger.info("Rewriting fillout lines into maf...")
+   group_size = len(mafDF.index) / 10 
+   dataframes = []
+   pool = multiprocessing.Pool(processes=5)
+   m = multiprocessing.Manager()
+   q = m.Queue()
+   for g, df in mafDF.groupby(np.arange(len(mafDF)) // group_size):
+       (cleanDF) = pool.apply_async(replace_allele_count, args=(args, df, filloutDF, q, ))
+#       (cleanDF) = replace_allele_count(args, mafDF, filloutDF, q)
+   pool.close()
+   pool.join()
+   while not q.empty():
+       dataframes.append(q.get())
+   write_output(args,dataframes)
    if(args.verbose):
        logger.info("replace_allele_counts: Finished the run for replacing allele counts.")
 
@@ -53,22 +63,44 @@ def read_maf(args):
     complex_variant_dataDF = dataDF.loc[dataDF['TYPE'] == "Complex"]
     return(complex_variant_dataDF,dataDF)
 
-def read_fillout(args):
+def read_fillout(args, maf_samples):
     dataDF = pd.read_table(args.fillout, comment="#", low_memory=False)
-    return(dataDF)
+    logger.info("sorting by chrom")
+    data_by_chrom_and_sample = {}
+    for chrom in dataDF['Chromosome'].unique():
+        if chrom not in data_by_chrom_and_sample:
+            data_by_chrom_and_sample[chrom]={}
+        for sample in dataDF['Tumor_Sample_Barcode'].unique():
+            #lets do this rough match once instead of every line
+            adjusted_sample_name = None
+            for mafsample in maf_samples:
+                if sample.find(mafsample) > -1:
+                    adjusted_sample_name = mafsample
+            if not adjusted_sample_name:
+                continue
+                #fillout can have more samples than maf, it turns out 
+                logger.critical("Unable to match fillout sample names with actual maf.")
+                logger.critical("Maf samples: %s" % " ".join(maf_samples))
+                logger.critical("Unmatched fillout sample id: %s" % sample)
+                sys.exit(1)
+            #data within the df is untouched, but it is organized in a double level dict by chr, sample name
+            #second level sample name matches maf sample name for O(1) into sample specific fillout list 
+            data_by_chrom_and_sample[chrom][adjusted_sample_name]=dataDF[(dataDF['Chromosome']== chrom) &
+                (dataDF['Tumor_Sample_Barcode']== sample)]
 
-def get_index_for_fillout(filloutDF,m_chr,m_start,m_end,m_ref,m_alt, m_sample_name):
+    return (data_by_chrom_and_sample)
+
+def get_index_for_fillout(data_chrom_sample,m_chr,m_start,m_end,m_ref,m_alt, m_sample_name):
     index = None
-    index = filloutDF[(filloutDF['Chromosome'] == m_chr) & 
-                           (filloutDF['Tumor_Sample_Barcode'].str.contains(m_sample_name)) & 
-                           (filloutDF['Start_Position'] == m_start) & 
+    filloutDF = data_chrom_sample[m_chr][m_sample_name]
+    index = filloutDF[(filloutDF['Start_Position'] == m_start) & 
                            (filloutDF['End_Position'] == m_end) & 
                            (filloutDF['Reference_Allele'] == m_ref) & 
                            (filloutDF['Tumor_Seq_Allele1'] == m_alt)].index.tolist()[0]
     return(index)
     
 
-def replace_allele_count(args,mafDF,filloutDF):
+def replace_allele_count(args,mafDF,filloutDF,q):
     mafDF_copy = mafDF.copy()
     for i_index, i_row in mafDF.iterrows():
         m_chr = i_row.loc['Chromosome']
@@ -83,7 +115,7 @@ def replace_allele_count(args,mafDF,filloutDF):
         
         #if(len(m_ref) >= 2 and len(m_alt) >= 2 and (len(m_ref) != len(m_alt))):
         if(m_type == "Complex"):
-            logging.warn("replace_allele_counts: Skipping as complex event: %s, %d, %d, %s, %s", m_chr, m_start, m_end, m_ref, m_alt)
+            logger.warn("replace_allele_counts: Skipping as complex event: %s, %d, %d, %s, %s", m_chr, m_start, m_end, m_ref, m_alt)
             continue
         else:
             filloutIndexTumor = get_index_for_fillout(filloutDF, m_chr, m_start, m_end, m_ref, m_alt, m_tumor_sample_name)
@@ -91,28 +123,38 @@ def replace_allele_count(args,mafDF,filloutDF):
             if(filloutIndexTumor != None and filloutIndexNormal != None):
                 #tumor_recordToReplace = filloutDF.iloc[[filloutIndexTumor]]
                 #normal_recordToReplace = filloutDF.iloc[[filloutIndexNormal]]
-                mafDF_copy.set_value(i_index,"t_depth",filloutDF.get_value(filloutIndexTumor,"t_total_count"))
-                mafDF_copy.set_value(i_index,"t_ref_count",filloutDF.get_value(filloutIndexTumor,"t_ref_count"))
-                mafDF_copy.set_value(i_index,"t_alt_count",filloutDF.get_value(filloutIndexTumor,"t_alt_count"))
-                mafDF_copy.set_value(i_index,"n_depth",filloutDF.get_value(filloutIndexNormal,"t_total_count"))
-                mafDF_copy.set_value(i_index,"n_ref_count",filloutDF.get_value(filloutIndexNormal,"t_ref_count"))
-                mafDF_copy.set_value(i_index,"n_alt_count",filloutDF.get_value(filloutIndexNormal,"t_alt_count"))
+                mafDF_copy.set_value(i_index,"t_depth",filloutDF[m_chr][m_tumor_sample_name].get_value(filloutIndexTumor,"t_total_count"))
+                mafDF_copy.set_value(i_index,"t_ref_count",filloutDF[m_chr][m_tumor_sample_name].get_value(filloutIndexTumor,"t_ref_count"))
+                mafDF_copy.set_value(i_index,"t_alt_count",filloutDF[m_chr][m_tumor_sample_name].get_value(filloutIndexTumor,"t_alt_count"))
+                mafDF_copy.set_value(i_index,"n_depth",filloutDF[m_chr][m_normal_sample_name].get_value(filloutIndexNormal,"t_total_count"))
+                mafDF_copy.set_value(i_index,"n_ref_count",filloutDF[m_chr][m_normal_sample_name].get_value(filloutIndexNormal,"t_ref_count"))
+                mafDF_copy.set_value(i_index,"n_alt_count",filloutDF[m_chr][m_normal_sample_name].get_value(filloutIndexNormal,"t_alt_count"))
             else:
-                logging.warn("replace_allele_counts: Skipping as could not find index in fillout as conversion of vcf to maf failed: %s, %d, %d, %s, %s", m_chr, m_start, m_end, m_ref, m_alt)
+                logger.warn("replace_allele_counts: Skipping as could not find index in fillout as conversion of vcf to maf failed: %s, %d, %d, %s, %s", m_chr, m_start, m_end, m_ref, m_alt)
                 continue
-    return(mafDF_copy)
+    q.put(mafDF_copy)
+    return True 
 
-def write_output(args,output_DF):
+def write_output(args,frames):
     if(args.outdir):
         outFile = os.path.join(args.outdir,args.outputMaf)
     else:
         outFile = os.path.join(os.getcwd(),args.outputMaf)
-    output_DF.to_csv(outFile, sep='\t', index=False)
+    pd.concat(frames).to_csv(outFile, sep='\t', index=False)
     
 if __name__ == "__main__":
+    logger = logging.getLogger('replace_allele_counts')
+    logger.propagate=False
+    logger.setLevel(logging.DEBUG)
+    formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
+    ch=logging.StreamHandler()
+    ch.setLevel(logging.DEBUG)
+    ch.setFormatter(formatter)
+    logger.addHandler(ch)
+
     start_time = time.time()  
     main()
     end_time = time.time()
     totaltime = end_time - start_time
-    logging.info("replace_allele_counts: Elapsed time was %g seconds", totaltime)
+    logger.info("replace_allele_counts: Elapsed time was %g seconds", totaltime)
     sys.exit(0)

--- a/replace_allele_counts.py
+++ b/replace_allele_counts.py
@@ -14,12 +14,12 @@ import time
 import logging
 import multiprocessing
 
-#try:
-#    import coloredlogs
-#    coloredlogs.install(level='DEBUG')
-#except ImportError:
-#    logger.warning("replace_allele_counts: coloredlogs is not installed, please install it if you wish to see color in logs on standard out.")
-#    pass
+try:
+    import coloredlogs
+    coloredlogs.install(level='DEBUG')
+except ImportError:
+    logger.warning("replace_allele_counts: coloredlogs is not installed, please install it if you wish to see color in logs on standard out.")
+    pass
 try:
     import numpy as np
     import pandas as pd

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open('LICENSE') as f:
 
 setup(
     name='replace_allele_counts',
-    version='0.1.1',
+    version='0.2.0',
     description='Package for replaceing allele counts in maf using a fill out produce with GetBaseCountMultiSample',
     long_description=readme,
     author='Ronak Shah',

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,6 @@ setup(
     author_email='rons.shah@gmail.com',
     url='https://github.com/rhshah/remove_variants',
     license=license,
-    install_requires=['nose==1.3.7', 'pandas==0.16.2', 'coloredlogs==5.2','codecov==2.0.5', 'coverage==4.3.4'],
+    install_requires=['nose==1.3.7', 'pandas', 'coloredlogs==5.2','codecov==2.0.5', 'coverage==4.3.4'],
     packages=find_packages(exclude=('tests', 'docs'))
 )


### PR DESCRIPTION
* this sorts mutations in fillout by chrom/sample to reduce search time per variant (should more closely approximate linear rather than n squared time, but still not a guaranteed linear streaming merge of these files)
* uses multiprocessing to process 5 chunks at a time, makes 10 chunks total 

tested on real data from donoghum project-- 50hrs ---> 4minutes 

